### PR TITLE
add transactions per goal + fixes

### DIFF
--- a/src/components/dashboard/balance-section.jsx
+++ b/src/components/dashboard/balance-section.jsx
@@ -89,13 +89,21 @@ export const BalanceSection = ({ auth, setTransacciones, balance, setBalance }) 
                                     Saldo
                                 </h3>
                                 {
-                                    divisa === "ARS"
-                                        ?
-                                        balance.data ?
-                                            balance.data.saldo_Total < 0 ?
+                                    !balance?.saldo_Total ?
+                                        <h1 className={(dark === "light" ?
+                                            "text-gray-600 font-bold text-5xl font-mono"
+                                            : "text-gray-200 font-bold text-5xl font-mono"
+                                        )}
+                                        >
+                                            <span className="mr-1">$</span>
+                                            {parseFloat(0).toFixed(2)}
+                                        </h1> :
+                                        divisa === "ARS"
+                                            ?
+                                            balance?.saldo_Total < 0 ?
                                                 <h1 className='text-red-500 font-bold text-5xl font-mono'>
                                                     <span className="mr-1">$</span>
-                                                    {parseFloat(balance.data.saldo_Total).toFixed(2)}
+                                                    {parseFloat(balance?.saldo_Total).toFixed(2)}
                                                 </h1> :
                                                 <h1 className={(dark === "light" ?
                                                     "text-gray-600 font-bold text-5xl font-mono"
@@ -103,52 +111,26 @@ export const BalanceSection = ({ auth, setTransacciones, balance, setBalance }) 
                                                 )}
                                                 >
                                                     <span className="mr-1">$</span>
-                                                    {parseFloat(balance.data.saldo_Total).toFixed(2)}
+                                                    {parseFloat(balance?.saldo_Total).toFixed(2)}
                                                 </h1> :
-                                            balance.saldo_Total < 0 ?
-                                                <h1 className='text-red-600 font-bold text-5xl font-mono'>
-                                                    <span className="mr-1">$</span>
-                                                    {parseFloat(balance.saldo_Total).toFixed(2)}
-                                                </h1> :
-                                                <h1 className={(dark === "light" ?
-                                                    "text-gray-600 font-bold text-5xl font-mono"
-                                                    : "text-gray-200 font-bold text-5xl font-mono"
-                                                )}>
-                                                    <span className="mr-1">$</span>
-                                                    {parseFloat(balance.saldo_Total).toFixed(2)}
-                                                </h1>
-                                        :
-                                        divisa === "USD"
-                                            ?
-                                            balance.data ?
-                                                balance.data.saldo_Total < 0 ?
+                                            divisa === "USD"
+                                                ?
+                                                balance?.saldo_Total < 0 ?
                                                     <h1 className='text-red-500 font-bold text-5xl font-mono'>
                                                         <span className="mr-1">U$S</span>
-                                                        {parseFloat(balance.data.saldo_Total / dolarValue).toFixed(2)}
+                                                        {parseFloat(balance?.saldo_Total / dolarValue).toFixed(2)}
                                                     </h1> :
                                                     <h1 className={(dark === "light" ?
                                                         "text-gray-600 font-bold text-5xl font-mono"
                                                         : "text-gray-200 font-bold text-5xl font-mono"
                                                     )}>
                                                         <span className="mr-1">U$S</span>
-                                                        {parseFloat(balance.data.saldo_Total / dolarValue).toFixed(2)}
-                                                    </h1> :
-                                                balance.saldo_Total < 0 ?
-                                                    <h1 className='text-red-600 font-bold text-5xl font-mono'>
-                                                        <span className="mr-1">U$S</span>
-                                                        {parseFloat(balance.saldo_Total / dolarValue).toFixed(2)}
-                                                    </h1> :
-                                                    <h1 className={(dark === "light" ?
-                                                        "text-gray-600 font-bold text-5xl font-mono"
-                                                        : "text-gray-200 font-bold text-5xl font-mono"
-                                                    )}>
-                                                        <span className="mr-1">U$S</span>
-                                                        {parseFloat(balance.saldo_Total / dolarValue).toFixed(2)}
+                                                        {parseFloat(balance?.saldo_Total / dolarValue).toFixed(2)}
                                                     </h1>
-                                            :
-                                            <div className="flex justify-center">
-                                                <PulseLoader loading={cargando} color="rgb(113, 50, 255)" size={10} />
-                                            </div>
+                                                :
+                                                <div className="flex justify-center">
+                                                    <PulseLoader loading={cargando} color="rgb(113, 50, 255)" size={10} />
+                                                </div>
                                 }
                                 <br />
                                 {

--- a/src/components/dashboard/last-goals-section.jsx
+++ b/src/components/dashboard/last-goals-section.jsx
@@ -5,7 +5,15 @@ import ModalMetas from "../pop-ups/ModalMetas";
 import { texts } from "../../constants/myfinances-constants";
 import useDark from "../../context/useDark";
 
-export const LastGoal = ({ activeGoals, auth, cargando, setActiveGoals, setBalance, balance }) => {
+export const LastGoal = ({
+    activeGoals,
+    auth,
+    cargando,
+    setActiveGoals,
+    setBalance,
+    balance,
+    setTransacciones
+}) => {
     const orderedList = activeGoals?.sort((a, b) => ((b.montoActual / b.montoFinal) - (a.montoActual / a.montoFinal)));
     const almostCompletedGoal = orderedList?.filter((g) => !g.completada);
     const [modal, setModal] = useState(false);
@@ -103,6 +111,7 @@ export const LastGoal = ({ activeGoals, auth, cargando, setActiveGoals, setBalan
                                             activeGoals={activeGoals}
                                             setBalance={setBalance}
                                             balance={balance}
+                                            setTransacciones={setTransacciones}
                                         />
                                     }
                                 </div>

--- a/src/components/dashboard/transactions/all-transactions-section.jsx
+++ b/src/components/dashboard/transactions/all-transactions-section.jsx
@@ -76,14 +76,26 @@ export const AllTransactionsSection = ({ transacciones, cargando }) => {
                                                 >{transaccion.detalle}</td>
                                                 {
                                                     transaccion.tipoTransaccion === type.EGRESO ?
-                                                        <td className="py-2 px-20 text-red-500 font-semibold font-mono">-${parseFloat(transaccion.monto).toFixed(2)}</td> :
+                                                        <td className="py-2 px-20 text-red-500 font-semibold font-mono">
+                                                            -${parseFloat(transaccion.monto).toFixed(2)}
+                                                        </td> :
                                                         transaccion.tipoTransaccion === type.INGRESO ?
                                                             <td className="py-2 px-20 text-green-500 font-semibold font-mono">
                                                                 <div className="w-28 flex justify-center rounded-md bg-green-200">
                                                                     +${parseFloat(transaccion.monto).toFixed(2)}
                                                                 </div>
                                                             </td> :
-                                                            <td></td>
+                                                            transaccion.tipoTransaccion === type.RESERVA ?
+                                                                transaccion.detalle?.includes("Retiro") ?
+                                                                    <td className="py-2 px-20 text-green-500 font-semibold font-mono">
+                                                                        <div className="w-28 flex justify-center rounded-md bg-green-200">
+                                                                            +${parseFloat(transaccion.monto).toFixed(2)}
+                                                                        </div>
+                                                                    </td> :
+                                                                    <td className="py-2 px-20 text-red-500 font-semibold font-mono">
+                                                                        -${parseFloat(transaccion.monto).toFixed(2)}
+                                                                    </td>
+                                                                : <td></td>
                                                 }
                                                 {
                                                     transaccion.fecha ?
@@ -99,7 +111,7 @@ export const AllTransactionsSection = ({ transacciones, cargando }) => {
                                                     transaccion && transaccion.tipoTransaccion === type.EGRESO ?
                                                         <td className="py-2 px-20 text-gray-400">
                                                             {transaccion.tipoTransaccion}
-                                                            <span className="text-red-500 font-bold ml-1">
+                                                            <span className="text-red-500 font-bold ml-1 pointer-events-none">
                                                                 <i className="fa-solid fa-arrow-trend-down"></i>
                                                             </span>
                                                         </td>
@@ -107,11 +119,16 @@ export const AllTransactionsSection = ({ transacciones, cargando }) => {
                                                         transaccion && transaccion.tipoTransaccion === type.INGRESO ?
                                                             <td className="py-2 px-20 text-gray-400">
                                                                 {transaccion.tipoTransaccion}
-                                                                <span className="text-green-500 font-bold ml-1">
+                                                                <span className="text-green-500 font-bold ml-1 pointer-events-none">
                                                                     <i className="fa-solid fa-arrow-trend-up"></i>
                                                                 </span>
-                                                            </td>
-                                                            : <td></td>
+                                                            </td> :
+                                                            transaccion.tipoTransaccion === type.RESERVA ?
+                                                                <td className="py-2 px-20 text-gray-400">
+                                                                    {transaccion.tipoTransaccion}
+                                                                    <i className="fa-solid fa-piggy-bank ml-1 pointer-events-none"></i>
+                                                                </td>
+                                                                : <td></td>
                                                 }
                                             </tr>
                                         );

--- a/src/components/goals/completed-goals.jsx
+++ b/src/components/goals/completed-goals.jsx
@@ -24,7 +24,10 @@ export const CompletedGoals = ({
     const completedGoals = goals?.filter(({ completada, retirada }) => completada && !retirada);
 
     const handleGoalWithdrawal = async (goalId) => {
-        setGoalLoading(true);
+        setGoalLoading({
+            ...goalLoading,
+            [goalId]: true
+        });
         const config = {
             headers: {
                 "Content-Type": "application/json",
@@ -34,7 +37,10 @@ export const CompletedGoals = ({
         try {
             const { data, status } = await withdrawGoal(goalId, config);
             if (status === 200) {
-                setGoalLoading(false);
+                setGoalLoading({
+                    ...goalLoading,
+                    [goalId]: false
+                });
                 setAlerta({
                     msg: texts.ON_WITHDRAWN_GOAL,
                     error: false
@@ -50,7 +56,10 @@ export const CompletedGoals = ({
                 }, 2000);
             }
         } catch (error) {
-            setGoalLoading(false);
+            setGoalLoading({
+                ...goalLoading,
+                [goalId]: false
+            });
             setError(error);
         }
     };
@@ -105,9 +114,9 @@ export const CompletedGoals = ({
                                             </div>
                                         </div>
                                         {
-                                            goalLoading ?
+                                            goalLoading[goal.id] ?
                                                 <div className="flex justify-center">
-                                                    <PulseLoader loading={goalLoading} color="rgb(113, 50, 255)" size={10} />
+                                                    <PulseLoader loading={goalLoading[goal.id]} color="rgb(113, 50, 255)" size={10} />
                                                 </div> :
                                                 <div className="flex justify-around">
                                                     <div className="w-32 text-center rounded-md bg-green-200">

--- a/src/components/pop-ups/ModalMetas.jsx
+++ b/src/components/pop-ups/ModalMetas.jsx
@@ -116,11 +116,7 @@ const ModalMetas = ({ setModal, animarModal, setAnimarModal, setActiveGoals, act
                             maxLength={30}
                             placeholder="Titulo de la meta"
                             value={tituloMeta}
-                            onChange={e => {
-                                if (textsReGex.test(e.target.value) || e.target.value === "") {
-                                    setTituloMeta(e.target.value);
-                                }
-                            }}
+                            onChange={e => setTituloMeta(e.target.value)}
                         />
                     </div>
 

--- a/src/components/pop-ups/ModalTransaccion.jsx
+++ b/src/components/pop-ups/ModalTransaccion.jsx
@@ -21,7 +21,6 @@ const ModalTransaccion = ({ setModal, animarModal, setAnimarModal, setTransaccio
     const [tipoTransaccion, setTipoTransaccion] = useState("Ingreso");
     const [categoriaId, setCategoria] = useState(categorias[0].id);
     const user = getUserToken();
-    const { dark } = useDark();
 
     const config = {
         headers: {
@@ -74,17 +73,29 @@ const ModalTransaccion = ({ setModal, animarModal, setAnimarModal, setTransaccio
                 setTimeout(() => {
                     setAlerta({});
                     setTransacciones(transacciones => [data, ...transacciones]);
-                    if (setBalance) {                        
+                    if (setBalance) {
                         if (data.tipoTransaccion === type.EGRESO) {
-                            setBalance({
-                                ...balance,
-                                saldo_Total: balance.saldo_Total - parseFloat(monto)
-                            });
+                            !balance.saldo_Total ?
+                                setBalance({
+                                    ...balance,
+                                    saldo_Total: parseFloat(monto)
+                                })
+                                :
+                                setBalance({
+                                    ...balance,
+                                    saldo_Total: balance.saldo_Total - parseFloat(monto)
+                                });
                         } else {
-                            setBalance({
-                                ...balance,
-                                saldo_Total: balance.saldo_Total + parseFloat(monto)
-                            });
+                            !balance.saldo_Total ?
+                                setBalance({
+                                    ...balance,
+                                    saldo_Total: parseFloat(monto)
+                                })
+                                :
+                                setBalance({
+                                    ...balance,
+                                    saldo_Total: balance.saldo_Total + parseFloat(monto)
+                                });
                         }
                     }
                     ocultarModal();
@@ -150,11 +161,7 @@ const ModalTransaccion = ({ setModal, animarModal, setAnimarModal, setTransaccio
                             maxLength={80}
                             placeholder="Detalle"
                             value={detalle}
-                            onChange={e => {
-                                if (textsReGex.test(e.target.value) || e.target.value === "") {
-                                    setDetalle(e.target.value);
-                                }
-                            }}
+                            onChange={e => setDetalle(e.target.value)}
                         />
                     </div>
                     <div className='campo'>

--- a/src/components/transactions/transactions-table.jsx
+++ b/src/components/transactions/transactions-table.jsx
@@ -137,20 +137,30 @@ export const TransactionsTable = ({ cargando, transacciones, setTransacciones, b
                                                     <td className="py-2 px-4 text-red-500 font-semibold font-mono">
                                                         -${parseFloat(transaccion.monto).toFixed(2)}
                                                     </td>
-                                                :
-                                                !transaccion.estaActiva
-                                                    ?
-                                                    <td className="py-2 px-4 text-gray-400 font-semibold font-mono">
-                                                        <div className="w-28 flex justify-center rounded-md bg-gray-200">
-                                                            +${parseFloat(transaccion.monto).toFixed(2)}
-                                                        </div>
-                                                    </td>
+                                                : transaccion.tipoTransaccion === type.INGRESO ?
+                                                    !transaccion.estaActiva
+                                                        ?
+                                                        <td className="py-2 px-4 text-gray-400 font-semibold font-mono">
+                                                            <div className="w-28 flex justify-center rounded-md bg-gray-200">
+                                                                +${parseFloat(transaccion.monto).toFixed(2)}
+                                                            </div>
+                                                        </td>
+                                                        :
+                                                        <td className="py-2 px-4 text-green-500 font-semibold font-mono">
+                                                            <div className="w-28 flex justify-center rounded-md bg-green-200">
+                                                                +${parseFloat(transaccion.monto).toFixed(2)}
+                                                            </div>
+                                                        </td>
                                                     :
-                                                    <td className="py-2 px-4 text-green-500 font-semibold font-mono">
-                                                        <div className="w-28 flex justify-center rounded-md bg-green-200">
-                                                            +${parseFloat(transaccion.monto).toFixed(2)}
-                                                        </div>
-                                                    </td>
+                                                    transaccion.detalle?.includes("Retiro") ?
+                                                        <td className="py-2 px-4 text-green-500 font-semibold font-mono">
+                                                            <div className="w-28 flex justify-center rounded-md bg-green-200">
+                                                                +${parseFloat(transaccion.monto).toFixed(2)}
+                                                            </div>
+                                                        </td> :
+                                                        <td className="py-2 px-4 text-red-500 font-semibold font-mono">
+                                                            -${parseFloat(transaccion.monto).toFixed(2)}
+                                                        </td>
                                         }
                                         {
                                             transaccion.fecha
@@ -180,12 +190,17 @@ export const TransactionsTable = ({ cargando, transacciones, setTransacciones, b
                                                     </span>
                                                 </td>
                                                 :
-                                                <td className="py-2 px-4 text-gray-400">
-                                                    {transaccion.tipoTransaccion}
-                                                    <span className="text-green-500 font-bold ml-2 pointer-events-none">
-                                                        <i className="fa-solid fa-arrow-trend-up"></i>
-                                                    </span>
-                                                </td>
+                                                transaccion.tipoTransaccion === type.INGRESO ?
+                                                    <td className="py-2 px-4 text-gray-400">
+                                                        {transaccion.tipoTransaccion}
+                                                        <span className="text-green-500 font-bold ml-2 pointer-events-none">
+                                                            <i className="fa-solid fa-arrow-trend-up"></i>
+                                                        </span>
+                                                    </td> :
+                                                    <td className="py-2 px-4 text-gray-400">
+                                                        {transaccion.tipoTransaccion}
+                                                        <i className="fa-solid fa-piggy-bank ml-2 pointer-events-none"></i>
+                                                    </td>
                                         }
                                         {
                                             !transaccion.estaActiva ?

--- a/src/constants/myfinances-constants.js
+++ b/src/constants/myfinances-constants.js
@@ -1,6 +1,7 @@
 export const type = {
     INGRESO: "Ingreso",
-    EGRESO: "Egreso"
+    EGRESO: "Egreso",
+    RESERVA: "Reserva"
 };
 
 export const errors = {

--- a/src/context/DarkProvider.jsx
+++ b/src/context/DarkProvider.jsx
@@ -31,7 +31,7 @@ const DarkProvider = ({ children }) => {
                 document.documentElement.style.setProperty("--gris", "#13159e");
                 document.documentElement.style.setProperty("--violetlight", "#A78BFA");
                 document.documentElement.style.setProperty("--gris-popup", "rgb(55 65 81)");
-                document.documentElement.style.setProperty("--negro", "rgb(75 85 99)");
+                document.documentElement.style.setProperty("--negro", "white");
             }
             localStorage.setItem("colorScheme", estadoDarkMode);
 

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -99,7 +99,7 @@ const Dashboard = () => {
             {
                 alertaTransacciones ?
                     <div className="flex justify-end">
-                        <div className="fixed">
+                        <div className="absolute">
                             {msg && <Alerta alerta={alertaTransacciones} />}
                         </div>
                     </div> : <div></div>
@@ -126,7 +126,8 @@ const Dashboard = () => {
                     cargando={cargando}
                     setActiveGoals={setActiveGoals}
                     balance={balance}
-                    setBalance={setBalance} />
+                    setBalance={setBalance}
+                    setTransacciones={setTransacciones} />
             </div>
             <div className={(dark === "light" ?
                 "bg-inherit p-10"

--- a/src/pages/SignUP/SignUp.jsx
+++ b/src/pages/SignUP/SignUp.jsx
@@ -24,6 +24,7 @@ const SignUp = () => {
         setLoading(true);
         /* Validación de campos */
         if ([nombre, apellido, email, contraseña, repetirPassword].includes("")) {
+            setLoading(false);
             setAlerta({
                 msg: "Todos los campos son obligatorios",
                 error: true
@@ -32,6 +33,7 @@ const SignUp = () => {
         }
 
         if (contraseña !== repetirPassword) {
+            setLoading(false);
             setAlerta({
                 msg: "No coinciden los password",
                 error: true
@@ -62,18 +64,11 @@ const SignUp = () => {
             setRepetirPassword("");
 
         } catch (error) {
-            if (contraseña.length < 6) {
-                setAlerta({
-                    msg: error.response.data.errors.Contraseña[0],
-                    error: true
-                });
-            }
-            else {
-                setAlerta({
-                    msg: error.response.data,
-                    error: true
-                });
-            }
+            setLoading(false);
+            setAlerta({
+                msg: error.response.data,
+                error: true
+            });
             setTimeout(() => {
                 setAlerta({});
             }, 5000);


### PR DESCRIPTION
x cada monto que se vaya agregando a una meta activa ademas de extraer del saldo del balance que también salga en concepto de transaccion de tipo "reserva".

x otro lado, tambien se arreglan bugs como:
- cuando el usuario ingresa por primera vez no cambiaba el balance dinamicamente despues de agregar un monto para alguna meta desde el dashboard.
- cuando el usuario ingresa por primera vez no se agregaba la transaccion en concepto de reserva desde algun monto para alguna meta desde el dashboard.
-  cuando un nuevo usuario fijaba una nueva meta sin tener un balance previo no se estaba restando del balance y tiraba un error 500
- cuando se iniciaba la aplicacion en modo oscuro las letras de los formularios seguian en gris oscuro y para poder resolverlo habia que pasar primero a claro y volver a oscuro.
- cuando se hacia click en completar una meta el spinner se activaba para todas las metas completadas.
- cuando el usuario ingresaba por primera vez en la seccion de balance el saldo salia como NaN.

pendiente:
- Hay que revisar tambien como esta funcionando el grafico del balance... parece que no esta funcionando como corresponde por mas que trae siempre las ultimas 10 transacciones (pending)

- Hay que estudiar la idea de tener en el componente de balance unicamente todas las transacciones activas y quitar el estado (parece un poco innecesario tener el estado de la transaccion en una seccion donde solamente son relevantes los numeros vigentes) (pending)

- Agregar paginado a las metas (tanto a las cards como a las tablas) 
